### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,6 @@ dependencies:
     - python=3.8
     - pygimli=1.2.1
     - jupyterlab
+    - pip
+    - pip:
+        - empymod


### PR DESCRIPTION
`empymod` is missing from the dependencies. You encounter that error when running notebook 6