### PR TITLE
Restrict matplotlib

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,5 @@ dependencies:
     - python=3.8
     - pygimli=1.2.1
     - jupyterlab
-    - pip
-    - pip:
-        - empymod
+    - matplotlib<3.5
+    - empymod


### PR DESCRIPTION
`matplotlib>=3.5` with `pygimli=1.2.1` results in a `TypeError: int() argument must be a string, a bytes-like object or a number, not 'slice'` for the command `ax.plot(pg.x(data1), pg.y(data2), "ro");`. Restricting therefore matplotlib.

I also changed `empymod` to be installed with conda, as it is on conda-forge. This also allows to remove the `pip`.